### PR TITLE
fix permission denied error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ _Init () {
     chmod +x "zip.com"
     _Fetch "sqlite.com" "$SQLITE_URL";
     chmod +x "sqlite.com"
-    mkdir -p definitions
+    mkdir -m 755 -p definitions
     _Fetch "definitions/redbean.lua" "$DEFINITIONS_URL"
     umask $u;
 }


### PR DESCRIPTION
Since the script creates `definitions` directory without the write flag due to umask, `init` fails with `permission denied` error. This patch will add `-m 755` parameter to the mkdir command to create a writable directory.